### PR TITLE
allow setting of adsabs source repo and revision via env vars

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,6 +4,10 @@
 # Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
 VAGRANTFILE_API_VERSION = "2"
 
+options = {}
+options[:adsabs_source] = ENV['VAGRANT_ADSABS_SOURCE'] || 'http://github.com/adsabs/adsabs.git'
+options[:adsabs_revision] = ENV['VAGRANT_ADSABS_REVISION'] || 'master'
+
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
 
   # Every Vagrant virtual environment requires a box to build off of.
@@ -49,6 +53,10 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     config.vm.provision :puppet do |puppet|
       puppet.manifests_path = "manifests"
       puppet.manifest_file  = "site.pp"
+      puppet.facter = {
+        "adsabs_source" => options[:adsabs_source],
+        "adsabs_revision" => options[:adsabs_revision]
+      }
     end
 
 

--- a/manifests/stage2.pp
+++ b/manifests/stage2.pp
@@ -10,7 +10,8 @@ vcsrepo {"/proj/ads/adsabs":
   ensure        => latest,
   provider      => git,
   user          => vagrant,
-  source        => "https://github.com/vsudilov/adsabs.git";
+  source        => $adsabs_source,
+  revision      => $adsabs_revision,
 }
 
 # vcsrepo {"/vagrant/adsabs-fabric": #WARNING: This actually returns success even if it can't clone due to auth problems!!!


### PR DESCRIPTION
Turns out this is not really useful just yet for the intended purpose (running a clean environment to test a specific pull request) . In the absence of stub data you'd still have to manually set up tunnels to the production solr & mongo instances. Merge at your convenience or ignore for now.
