### PR TITLE
Use official release tag instead of master-next

### DIFF
--- a/dockerfiles/montysolr/Dockerfile
+++ b/dockerfiles/montysolr/Dockerfile
@@ -9,7 +9,9 @@ ENV LC_ALL en_US.UTF-8
 ENV JAVA_HOME /usr/lib/jvm/java-7-openjdk-amd64/
 ENV ANT_HOME /usr/share/ant
 
-RUN git clone -b master-next https://github.com/romanchyla/montysolr.git /montysolr
+RUN git clone https://github.com/romanchyla/montysolr.git /montysolr
+RUN cd /montysolr && git checkout --force master && git fetch --tags
+RUN cd /montysolr && git checkout --force `git describe --tags $(git rev-list --tags --max-count=1)`
 RUN cd /montysolr && ant ivy-bootstrap && ant build-all
 
 EXPOSE 8983


### PR DESCRIPTION
this is much safer; tested with latest docker.io and vagrant